### PR TITLE
Upgrade to Dropwizard 1.0.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# IntelliJ Files
+.idea/
+*.ipr
+*.iws
+*.iml
+
+# Eclipse Files
+.classpath
+.project
+
+# Build outputs
+target/
+dependency-reduced-pom.xml
+
+# Vagrant outputs
+.vagrant
+
+# OS hidden files
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>dropwizard-parent-pom</artifactId>
-  <version>1.0.5-8-SNAPSHOT</version>
+  <version>1.0.9-1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <scm>
@@ -20,14 +20,15 @@
   </scm>
 
   <properties>
-    <dropwizard.version>1.0.5</dropwizard.version>
+    <dropwizard.version>1.0.9</dropwizard.version>
 
     <!--
       This version needs to stay EXACTLY the same as the one that the Dropwizard BOM
       specifies.  Unfortunately when you import a BOM you don't get its properties, only
       its dependencies.
     -->
-    <jackson.version>2.7.8</jackson.version>
+    <jackson.version>2.7.9.1</jackson.version>
+    <jackson.module.parameter.names.version>2.7.9</jackson.module.parameter.names.version>
 
     <!--
       These versions should remain consistent with the version of Dropwizard being specified.
@@ -180,7 +181,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-parameter-names</artifactId>
-        <version>${jackson.version}</version>
+        <version>${jackson.module.parameter.names.version}</version>
       </dependency>
 
       <!-- Main Street Hub authored bundles to use with Dropwizard. -->

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,16 @@ child pom.
 
 ### Releases
 
-#### 1.0.5-5
+#### 1.0.9-1
+
+* Upgrading Dropwizard to 1.0.9
+* Improved testing to detect missing dependencies
+
+#### 1.0.5-7
+
+* Upgraded parent POM, `com.mainstreethub:ecs-parent-pom`, to 1.3.2
+
+#### 1.0.5-6
 
 * Upgraded parent POM, `com.mainstreethub:ecs-parent-pom`, to 1.3.1
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -36,6 +36,26 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.0.1</version>
+        <executions>
+          <execution>
+            <id>analyze</id>
+            <goals>
+              <goal>analyze-only</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <failOnWarning>true</failOnWarning>
+              <ignoreNonCompile>false</ignoreNonCompile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 


### PR DESCRIPTION
Upgrading to Dropwizard 1.0.9, it contains security fixes for both Jetty and Jackson:

https://github.com/dropwizard/dropwizard/releases/tag/v1.0.9