### PR TITLE
Update to json log bundle 1.1.4-2 (username logging) [HUBP-203]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     -->
     <dropwizard.api.key.bundle.version>1.1.4-1</dropwizard.api.key.bundle.version>
     <dropwizard.configurable.assets.bundle.version>1.1.4</dropwizard.configurable.assets.bundle.version>
-    <dropwizard.json.log.bundle.version>1.1.4-1</dropwizard.json.log.bundle.version>
+    <dropwizard.json.log.bundle.version>1.1.4-2</dropwizard.json.log.bundle.version>
     <dropwizard.redirect.bundle.version>1.1.4</dropwizard.redirect.bundle.version>
     <dropwizard.template.config.version>1.5.0</dropwizard.template.config.version>
     <dropwizard.version.bundle.version>1.1.4</dropwizard.version.bundle.version>


### PR DESCRIPTION
* json log bundle 1.1.4-2 encodes any user associated with the request into a `remote_user` field
* without this change, the default logstash request encoder uses `@fields.remote_user` which
is incompatible with logstash
