### PR TITLE
Upgrade kotlin to 1.3.21

### DIFF
--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -116,6 +116,22 @@
           </exclusion>
         </exclusions>
       </dependency>
+
+      <dependency>
+        <groupId>com.mainstreethub</groupId>
+        <artifactId>ktdropwizard-core</artifactId>
+        <version>${mainstreethub.java-commons.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -15,11 +15,11 @@
   <properties>
     <jdbi.version>3.2.1</jdbi.version>
 
-    <klint-maven-plugin.version>0.9.21</klint-maven-plugin.version>
+    <klint-maven-plugin.version>0.9.24</klint-maven-plugin.version>
 
     <kotlin.version>1.3.21</kotlin.version>
     <kotlin-coroutine.version>1.1.1</kotlin-coroutine.version>
-    <kotlin-logging.version>1.6.24</kotlin-logging.version>
+    <kotlin-logging.version>1.6.26</kotlin-logging.version>
   </properties>
 
   <build>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -15,11 +15,11 @@
   <properties>
     <jdbi.version>3.2.1</jdbi.version>
 
-    <klint-maven-plugin.version>0.9.16</klint-maven-plugin.version>
+    <klint-maven-plugin.version>0.9.21</klint-maven-plugin.version>
 
-    <kotlin.version>1.3.10</kotlin.version>
-    <kotlin-coroutine.version>1.1.0</kotlin-coroutine.version>
-    <kotlin-logging.version>1.6.22</kotlin-logging.version>
+    <kotlin.version>1.3.21</kotlin.version>
+    <kotlin-coroutine.version>1.1.1</kotlin-coroutine.version>
+    <kotlin-logging.version>1.6.24</kotlin-logging.version>
   </properties>
 
   <build>
@@ -143,7 +143,6 @@
                 <phase>none</phase>
               </execution>
             </executions>
-
           </plugin>
 
           <plugin>
@@ -153,6 +152,7 @@
             <configuration>
               <args>
                 <arg>-java-parameters</arg>
+                <arg>-Werror</arg>
               </args>
             </configuration>
             <executions>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -142,6 +142,11 @@
                 <id>default-compile</id>
                 <phase>none</phase>
               </execution>
+
+              <execution>
+                <id>default-testCompile</id>
+                <phase>none</phase>
+              </execution>
             </executions>
           </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <dropwizard.version.bundle.version>1.3.5</dropwizard.version.bundle.version>
     <dropwizard.webjars.bundle.version>1.3.5</dropwizard.webjars.bundle.version>
 
-    <mainstreethub.java-commons.version>1.3.5-5</mainstreethub.java-commons.version>
+    <mainstreethub.java-commons.version>1.3.5-8</mainstreethub.java-commons.version>
 
     <maven.failsafe.plugin.version>2.22.1</maven.failsafe.plugin.version>
     <maven.surefire.plugin.version>2.22.1</maven.surefire.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,11 +50,36 @@
     <dropwizard.webjars.bundle.version>1.3.5</dropwizard.webjars.bundle.version>
 
     <mainstreethub.java-commons.version>1.3.5-5</mainstreethub.java-commons.version>
+
+    <maven.failsafe.plugin.version>2.22.1</maven.failsafe.plugin.version>
+    <maven.surefire.plugin.version>2.22.1</maven.surefire.plugin.version>
   </properties>
 
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven.surefire.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${maven.failsafe.plugin.version}</version>
+          <configuration>
+            <classpathDependencyScopeExclude>compile</classpathDependencyScopeExclude>
+          </configuration>
+
+          <executions>
+            <execution>
+              <goals>
+                <goal>integration-test</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
         <plugin>
           <groupId>io.fabric8</groupId>
           <artifactId>docker-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <dropwizard.version.bundle.version>1.3.5</dropwizard.version.bundle.version>
     <dropwizard.webjars.bundle.version>1.3.5</dropwizard.webjars.bundle.version>
 
-    <mainstreethub.java-commons.version>1.3.5-8</mainstreethub.java-commons.version>
+    <mainstreethub.java-commons.version>1.3.5-9</mainstreethub.java-commons.version>
 
     <maven.failsafe.plugin.version>2.22.1</maven.failsafe.plugin.version>
     <maven.surefire.plugin.version>2.22.1</maven.surefire.plugin.version>

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ child pom.
 * Upgrade to Kotlin coroutines 1.1.1
 * Upgrade to kotlin-maven-plugin 0.9.24
 * Upgrade to kotlin-logging 1.6.26
-* Upgrade to java-commons 1.3.5-8
+* Upgrade to java-commons 1.3.5-9, includes ktdropwizard
 * Specify failsafe and surefire plugin versions and standard configuration (initial version 2.22.1)
 * default-testCompile should be disable to prevent warnings from Java compiler
 * Add flag to Kotlin compiler to fail on warnings (Helps to prevent bugs around unused parameters)

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,15 @@ child pom.
 
 ### Releases
 
+#### 1.3.5-6
+* Upgrade to Kotlin 1.3.21
+* Upgrade to kotlin-maven-plugin 0.9.24
+* Upgrade to kotlin-logging 1.6.26
+* Upgrade to java-commons 1.3.5-8
+
+#### 1.3.5-5
+* Migrate to GoDaddy slack for build notifications
+
 #### 1.3.5-4
 * Remove ktlint format so it is not executed
 

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ child pom.
 * Upgrade to kotlin-maven-plugin 0.9.24
 * Upgrade to kotlin-logging 1.6.26
 * Upgrade to java-commons 1.3.5-8
+* Specify failsafe and surefire plugin versions and standard configuration (initial version 2.22.1)
 
 #### 1.3.5-5
 * Migrate to GoDaddy slack for build notifications

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,8 @@ child pom.
 * Upgrade to kotlin-logging 1.6.26
 * Upgrade to java-commons 1.3.5-8
 * Specify failsafe and surefire plugin versions and standard configuration (initial version 2.22.1)
+* default-testCompile should be disable to prevent warnings from Java compiler
+* Add flag to Kotlin compiler to fail on warnings (Helps to prevent bugs around unused parameters)
 
 #### 1.3.5-5
 * Migrate to GoDaddy slack for build notifications

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ child pom.
 
 #### 1.3.5-6
 * Upgrade to Kotlin 1.3.21
+* Upgrade to Kotlin coroutines 1.1.1
 * Upgrade to kotlin-maven-plugin 0.9.24
 * Upgrade to kotlin-logging 1.6.26
 * Upgrade to java-commons 1.3.5-8


### PR DESCRIPTION
* Upgrade to Kotlin 1.3.21
* Upgrade to Kotlin coroutines 1.1.1
* Upgrade to kotlin-maven-plugin 0.9.24
* Upgrade to kotlin-logging 1.6.26
* Upgrade to java-commons 1.3.5-8
* Specify failsafe and surefire plugin versions and standard configuration (initial version 2.22.1)